### PR TITLE
Added kwargs for get/post/put methods so url params will work

### DIFF
--- a/backbone/views.py
+++ b/backbone/views.py
@@ -29,7 +29,6 @@ class BackboneAPIView(View):
         """
         Handles get requests for either the collection or an object detail.
         """
-        import ipdb; ipdb.set_trace()
         if id:
             obj = get_object_or_404(self.queryset(request, **kwargs), id=id)
             return self.get_object_detail(request, obj)


### PR DESCRIPTION
When creating a custom view and adding it manually to urls.py adding url params won't work since the
get/post/put methods are not expecting kwargs.
