### PR TITLE
Updates for urls contructions

### DIFF
--- a/backbone/sites.py
+++ b/backbone/sites.py
@@ -21,6 +21,9 @@ class BackboneSite(object):
         except ImportError:  # For backwards compatibility with Django <=1.3
             from django.conf.urls.defaults import patterns, url
 
+        from django.conf import settings
+        url_end = '/$' if hasattr(settings, 'APPEND_SLASH') and settings.APPEND_SLASH else '$'
+
         urlpatterns = patterns('')
         for view_class in self._registry:
             app_label = view_class.model._meta.app_label
@@ -30,8 +33,8 @@ class BackboneSite(object):
             base_url_name = '%s_%s' % (app_label, url_slug)
 
             urlpatterns += patterns('',
-                url(url_path_prefix + '/$', view_class.as_view(), name=base_url_name),
-                url(url_path_prefix + '/(?P<id>\d+)/$', view_class.as_view(),
+                url(url_path_prefix + url_end, view_class.as_view(), name=base_url_name),
+                url(url_path_prefix + '/(?P<id>\d+)' + url_end, view_class.as_view(),
                     name=base_url_name + '_detail')
             )
         return urlpatterns

--- a/backbone/sites.py
+++ b/backbone/sites.py
@@ -26,7 +26,7 @@ class BackboneSite(object):
             app_label = view_class.model._meta.app_label
             url_slug = view_class.url_slug or view_class.model._meta.module_name
 
-            url_path_prefix = r'^%s/%s' % (app_label, url_slug)
+            url_path_prefix = r'^(?P<app_label>%s)/(?P<url_slug>%s)' % (app_label, url_slug)
             base_url_name = '%s_%s' % (app_label, url_slug)
 
             urlpatterns += patterns('',

--- a/backbone/sites.py
+++ b/backbone/sites.py
@@ -30,8 +30,8 @@ class BackboneSite(object):
             base_url_name = '%s_%s' % (app_label, url_slug)
 
             urlpatterns += patterns('',
-                url(url_path_prefix + '$', view_class.as_view(), name=base_url_name),
-                url(url_path_prefix + '/(?P<id>\d+)$', view_class.as_view(),
+                url(url_path_prefix + '/$', view_class.as_view(), name=base_url_name),
+                url(url_path_prefix + '/(?P<id>\d+)/$', view_class.as_view(),
                     name=base_url_name + '_detail')
             )
         return urlpatterns

--- a/backbone/views.py
+++ b/backbone/views.py
@@ -117,11 +117,11 @@ class BackboneAPIView(View):
             response = self.get_object_detail(request, obj)
             response.status_code = 201
 
-            url_name = 'backbone:%s_%s_detail' % (
-                self.model._meta.app_label,
-                self.url_slug or self.model._meta.module_name
-            )
-            response['Location'] = reverse(url_name, args=[obj.id])
+            app_label = self.model._meta.app_label
+            url_slug = self.url_slug or self.model._meta.module_name
+
+            url_name = 'backbone:%s_%s_detail' % (app_label, url_slug)
+            response['Location'] = reverse(url_name, args=[app_label, url_slug, obj.id]) 
             return response
         else:
             return HttpResponseBadRequest(self.json_dumps(form.errors), content_type='application/json')
@@ -176,7 +176,7 @@ class BackboneAPIView(View):
             defaults['fields'] = self.fields
         return modelform_factory(self.model, **defaults)(data=data, instance=instance)
 
-    def delete(self, request, id=None):
+    def delete(self, request, id=None, **kwargs):
         """
         Handles delete requests.
         """


### PR DESCRIPTION
By default [APPEND_SLASH](https://docs.djangoproject.com/en/dev/ref/settings/#append-slash) is set to `true` in django, which helps to handle urls like 'api/' and 'api' in the same way, more than that - this setting tells django to redirect from 'api' to 'api/' with 301. To make it work you need always to keep slash at the end of url.

The other change is about helping to resolve app_label and url_slug when you call resolve function directly to find for which application this url has been created.
