### PR TITLE
Django >= 1.9 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ develop-eggs
 
 # Installer logs
 pip-log.txt
+MANIFEST
 
 # Unit test / coverage reports
 .coverage

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+0.3.2
+-----
+
+* Adds support for Django 1.7
+* Adds has_get_permission hook
+
+
 0.3.1
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -157,10 +157,10 @@ Running the tests
 ::
 
     # For Django 1.6+
-    ./manage.py test backbone.tests --settings=backbone.tests.settings
+    django-admin test backbone.tests --settings=backbone.tests.settings
 
     # For Django < 1.6
-    ./manage.py test tests --settings=backbone.tests.settings
+    django-admin test tests --settings=backbone.tests.settings
 
 
 

--- a/backbone/__init__.py
+++ b/backbone/__init__.py
@@ -1,5 +1,7 @@
 """Provides a Backbone.js compatible REST API for your models using Django Admin style registration."""
 
+from __future__ import unicode_literals
+
 from backbone.sites import BackboneSite
 
 
@@ -17,7 +19,12 @@ def autodiscover():
     """
     # This code is based off django.contrib.admin.__init__
     from django.conf import settings
-    from django.utils.importlib import import_module
+    try:
+        # Django versions >= 1.9
+        from django.utils.module_loading import import_module
+    except ImportError:
+        # Django versions < 1.9
+        from django.utils.importlib import import_module
     from django.utils.module_loading import module_has_submodule
     from backbone.views import BackboneAPIView  # This is to prevent a circular import issue
 

--- a/backbone/sites.py
+++ b/backbone/sites.py
@@ -19,7 +19,7 @@ class BackboneSite(object):
             self._registry.remove(backbone_view_class)
 
     def get_urls(self):
-        from django.conf.urls import patterns, url
+        from django.conf.urls import url
 
         urlpatterns = []
         for view_class in self._registry:

--- a/backbone/sites.py
+++ b/backbone/sites.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+
 class BackboneSite(object):
 
     def __init__(self, name='backbone'):
@@ -18,7 +21,7 @@ class BackboneSite(object):
     def get_urls(self):
         from django.conf.urls import patterns, url
 
-        urlpatterns = patterns('')
+        urlpatterns = []
         for view_class in self._registry:
             app_label = view_class.model._meta.app_label
 
@@ -30,11 +33,11 @@ class BackboneSite(object):
             url_path_prefix = r'^%s/%s' % (app_label, url_slug)
             base_url_name = '%s_%s' % (app_label, url_slug)
 
-            urlpatterns += patterns('',
+            urlpatterns = urlpatterns + [
                 url(url_path_prefix + '$', view_class.as_view(), name=base_url_name),
                 url(url_path_prefix + '/(?P<id>\d+)$', view_class.as_view(),
                     name=base_url_name + '_detail')
-            )
+            ]
         return urlpatterns
 
     @property

--- a/backbone/tests/admin.py
+++ b/backbone/tests/admin.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.contrib import admin
 
 from backbone.tests.models import Product, Brand

--- a/backbone/tests/backbone_api.py
+++ b/backbone/tests/backbone_api.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import backbone
 from backbone.views import BackboneAPIView
 from backbone.tests.forms import BrandForm

--- a/backbone/tests/forms.py
+++ b/backbone/tests/forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 

--- a/backbone/tests/models.py
+++ b/backbone/tests/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 

--- a/backbone/tests/settings.py
+++ b/backbone/tests/settings.py
@@ -1,8 +1,17 @@
+from __future__ import unicode_literals
+
 import os
 
 # Settings for running tests.
 
 DEBUG = True
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True
+    },
+]
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/backbone/tests/tests.py
+++ b/backbone/tests/tests.py
@@ -667,5 +667,5 @@ class InvalidViewTests(TestHelper):
         url = reverse('backbone:tests_brand_detail', args=[brand.id])
         try:
             self.client.get(url)
-        except AttributeError, err:
+        except AttributeError as err:
             self.assertEqual(str(err), "Invalid field: invalid_field")

--- a/backbone/tests/tests.py
+++ b/backbone/tests/tests.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 from decimal import Decimal
 import json
@@ -191,7 +193,7 @@ class CollectionTests(TestHelper):
 class DetailTests(TestHelper):
 
     def test_detail_view_returns_object_details(self):
-        product = self.create_product(price=3)
+        product = self.create_product(price='3.00')
         category = self.create_category()
         product.categories.add(category)
 
@@ -202,7 +204,7 @@ class DetailTests(TestHelper):
         self.assertEqual(data['name'], product.name)
         self.assertEqual(data['brand'], product.brand.id)
         self.assertEqual(data['categories'], [category.id])
-        self.assertEqual(data['price'], str(product.price))
+        self.assertEqual(data['price'], product.price)
         self.assertEqual(data['order'], product.order)
         # Attribute on model
         self.assertEqual(data['is_priced_under_10'], True)
@@ -342,9 +344,9 @@ class AddTests(TestHelper):
         self.assertEqual(data['categories'], [cat1.id, cat2.id])
         self.assertEqual(data['price'], '12.34')
 
-        self.assertEqual(response['Location'], 'http://testserver' \
-            + reverse('backbone:tests_product_detail', args=[product.id])
-        )
+        self.assertTrue(response['Location'].endswith(
+            reverse('backbone:tests_product_detail', args=[product.id])
+        ))
 
     def test_post_request_on_product_collection_view_with_invalid_json_returns_error(self):
         url = reverse('backbone:tests_product')
@@ -441,12 +443,9 @@ class AddTests(TestHelper):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Brand.objects.count(), 1)
 
-        self.assertEqual(
-            response['Location'],
-            'http://testserver' + reverse(
-                'backbone:tests_brand_alternate_detail', args=[Brand.objects.get().id]
-            )
-        )
+        self.assertTrue(response['Location'].endswith(reverse(
+            'backbone:tests_brand_alternate_detail', args=[Brand.objects.get().id]
+        )))
 
 
 class UpdateTests(TestHelper):
@@ -635,7 +634,7 @@ class DeleteTests(TestHelper):
 class InheritanceTests(TestHelper):
 
     def test_detail_view_returns_inherited_object_details(self):
-        ext_product = self.create_extended_product(price=9)
+        ext_product = self.create_extended_product(price='9.00')
         category = self.create_category()
         ext_product.categories.add(category)
 
@@ -646,7 +645,7 @@ class InheritanceTests(TestHelper):
         self.assertEqual(data['name'], ext_product.name)
         self.assertEqual(data['brand'], ext_product.brand.id)
         self.assertEqual(data['categories'], [category.id])
-        self.assertEqual(data['price'], str(ext_product.price))
+        self.assertEqual(data['price'], ext_product.price)
         self.assertEqual(data['order'], ext_product.order)
         self.assertEqual(data['description'], ext_product.description)
         # Attribute on model

--- a/backbone/tests/urls.py
+++ b/backbone/tests/urls.py
@@ -1,14 +1,17 @@
-from django.conf.urls import patterns, url, include
+from __future__ import unicode_literals
+
+from django.conf.urls import url, include
 from django.contrib import admin
 
 import backbone
 
-
 admin.autodiscover()
 backbone.autodiscover()
 
-urlpatterns = patterns('',
+from backbone.tests.views import homepage
+
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^backbone/', include(backbone.site.urls)),
-    url(r'^$', 'backbone.tests.views.homepage', name='tests-homepage'),
-)
+    url(r'^$', homepage, name='tests-homepage'),
+]

--- a/backbone/tests/views.py
+++ b/backbone/tests/views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.shortcuts import render
 
 

--- a/backbone/views.py
+++ b/backbone/views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 from django.core.serializers.json import DjangoJSONEncoder

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
     django1.7: Django==1.7.*
     django1.8: Django==1.8.*
     django1.9: Django==1.9.*
-    django1.10: Django==1.10a1
+    django1.10: Django==1.10.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist:
+    py27-django1.{8,9,10},
+    py34-django1.{8,9,10}
+
+[testenv]
+commands = django-admin test backbone.tests --settings=backbone.tests.settings
+basepython =
+    py27: python2.7
+    py34: python3.4
+deps =
+    django1.7: Django==1.7.*
+    django1.8: Django==1.8.*
+    django1.9: Django==1.9.*
+    django1.10: Django==1.10a1


### PR DESCRIPTION
This fixes a syntax error in the tests that allows you to run them when using python 3 (tested with 3.3).
Also adds a changelog for 0.3.2. Hopefuly 0.3.3 entry lists python 3 support :)

See #23.
